### PR TITLE
refactor: GPT-3.5 への差し戻し

### DIFF
--- a/src/service/chat.rs
+++ b/src/service/chat.rs
@@ -1,4 +1,3 @@
-use chatgpt::prelude::ChatGPTEngine::Gpt4;
 use chatgpt::types::CompletionResponse;
 use once_cell::sync::OnceCell;
 use serenity::model::prelude::Message;
@@ -21,7 +20,7 @@ async fn get_response(ctx: &Context, msg: &Message) -> anyhow::Result<Completion
 
     let content = msg.content.replace(mention, "").trim().to_string();
 
-    let response = request_message(content, Some(Gpt4)).await?;
+    let response = request_message(content, None).await?;
 
     Ok(response)
 }

--- a/src/service/reply.rs
+++ b/src/service/reply.rs
@@ -1,13 +1,13 @@
 use crate::client::openai::request_reply_message;
 use crate::model::{ReplyMessage, ReplyRole};
-use chatgpt::prelude::ChatGPTEngine::Gpt4;
 use once_cell::sync::OnceCell;
 use serenity::model::prelude::Message;
 use serenity::prelude::Context;
 
 pub async fn reply_mode(ctx: &Context, msg: &Message) -> anyhow::Result<()> {
     let replies = get_replies(ctx, msg).await?;
-    let response_message = request_reply_message(&replies, Some(Gpt4)).await?;
+    // notes: GPT-4 があまりにも高いため、GPT-3.5 に revert
+    let response_message = request_reply_message(&replies, None).await?;
 
     msg.reply(ctx, response_message).await?;
 


### PR DESCRIPTION
ichiyoAI のトークン提供者への負担がものすごいので、一時的にGPT-3.5へモデルを差し戻します.
