### PR TITLE
feat: サブスクライバー限定で GPT-4 を解放

### DIFF
--- a/src/client/openai.rs
+++ b/src/client/openai.rs
@@ -54,9 +54,9 @@ fn init_client(api_key: &str, model: Option<ChatGPTEngine>) -> anyhow::Result<Ch
 /// * 2000文字を超過する
 pub async fn request_message(
     content: String,
-    model: Option<ChatGPTEngine>,
+    model: ChatGPTEngine,
 ) -> anyhow::Result<CompletionResponse> {
-    let client = init_client(OPENAI_API_KEY.as_str(), model)?;
+    let client = init_client(OPENAI_API_KEY.as_str(), Some(model))?;
 
     let response = match timeout(TIMEOUT_DURATION, client.send_message(content)).await {
         Ok(result) => result.context("Failed to communicate with ChatGPT")?,
@@ -82,9 +82,9 @@ pub async fn request_message(
 /// [String]: ChatGPT からのレスポンス
 pub async fn request_reply_message(
     reply_messages: &[ReplyMessage],
-    model: Option<ChatGPTEngine>,
+    model: ChatGPTEngine,
 ) -> anyhow::Result<String> {
-    let client = init_client(OPENAI_API_KEY.as_str(), model)?;
+    let client = init_client(OPENAI_API_KEY.as_str(), Some(model))?;
 
     let history = reply_messages
         .iter()

--- a/src/service/chat.rs
+++ b/src/service/chat.rs
@@ -1,3 +1,4 @@
+use chatgpt::prelude::ChatGPTEngine;
 use chatgpt::types::CompletionResponse;
 use once_cell::sync::OnceCell;
 use serenity::model::prelude::Message;
@@ -5,8 +6,8 @@ use serenity::prelude::Context;
 
 use crate::client::openai::request_message;
 
-pub async fn chat_mode(ctx: &Context, msg: &Message) -> anyhow::Result<()> {
-    let response = get_response(ctx, msg).await?;
+pub async fn chat_mode(ctx: &Context, msg: &Message, model: ChatGPTEngine) -> anyhow::Result<()> {
+    let response = get_response(ctx, msg, model).await?;
     let reply_content = &response.message().content;
 
     msg.reply(ctx, reply_content).await?;
@@ -14,13 +15,17 @@ pub async fn chat_mode(ctx: &Context, msg: &Message) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn get_response(ctx: &Context, msg: &Message) -> anyhow::Result<CompletionResponse> {
+async fn get_response(
+    ctx: &Context,
+    msg: &Message,
+    model: ChatGPTEngine,
+) -> anyhow::Result<CompletionResponse> {
     static OWN_MENTION: OnceCell<String> = OnceCell::new();
     let mention = OWN_MENTION.get_or_init(|| format!("<@{}>", ctx.cache.current_user_id()));
 
     let content = msg.content.replace(mention, "").trim().to_string();
 
-    let response = request_message(content, None).await?;
+    let response = request_message(content, model).await?;
 
     Ok(response)
 }

--- a/src/service/reply.rs
+++ b/src/service/reply.rs
@@ -1,13 +1,14 @@
 use crate::client::openai::request_reply_message;
 use crate::model::{ReplyMessage, ReplyRole};
+use chatgpt::prelude::ChatGPTEngine;
 use once_cell::sync::OnceCell;
 use serenity::model::prelude::Message;
 use serenity::prelude::Context;
 
-pub async fn reply_mode(ctx: &Context, msg: &Message) -> anyhow::Result<()> {
+pub async fn reply_mode(ctx: &Context, msg: &Message, model: ChatGPTEngine) -> anyhow::Result<()> {
     let replies = get_replies(ctx, msg).await?;
     // notes: GPT-4 があまりにも高いため、GPT-3.5 に revert
-    let response_message = request_reply_message(&replies, None).await?;
+    let response_message = request_reply_message(&replies, model).await?;
 
     msg.reply(ctx, response_message).await?;
 


### PR DESCRIPTION
限界開発鯖をサーバーブーストした人のみ GPT-4 を使えるように
(ブーストのみ。Nitroサブスクライバー・Nitro Classicサブスクライバーだけのユーザーのリクエストは GPT-3.5 が使用されます)