### PR TITLE
fix: Docker コンテナ上のSSL認証エラーを修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ FROM debian:bullseye-slim as Runner
 
 COPY --from=Builder --chown=root:root /root/app/target/release/ichiyo_ai /usr/local/bin/ichiyo_ai
 
+RUN apt-get update && apt-get install -y libssl-dev ca-certificates
+
 RUN useradd --create-home --user-group ichiyo
 USER ichiyo
 WORKDIR /home/ichiyo


### PR DESCRIPTION
[approvers/containers2](https://github.com/approvers/containers2) で使用している共有サーバー上で展開している Docker コンテナで, OpenAI API Wrapper の1つである `chatgpt_rs` が使用する `reqwest` がSSL認証エラーにより正常に動作しなかったため修正しました. また同時にSSL関連の問題により sentry が正しくエラーを報告できていなかったのでそちらも修正しました.

ichiyoAI の Docker イメージ (RUN Stage) に `libssl-dev` `ca-certificates` をインストールすることで対処しました.
