### PR TITLE
chore: change base renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>m1sk9/renovate-config"
+    "config:recommended"
   ],
   "addLabels": [
     "renovate"


### PR DESCRIPTION
`m1sk9/renovate-config` はメンテナンスを終了します. このままだと依存関係の更新が行われなくなるため renovate の設定をメンテナ推奨の `config:recommended` に変更します.

もしほかに使用したい renovate config がある場合はこの PR はクローズしても構いません. 